### PR TITLE
do not ignore connection with "Invalid" in its name

### DIFF
--- a/vpn
+++ b/vpn
@@ -17,7 +17,7 @@ exit 1
 }
 
 function connections() {
-  scutil --nc list | grep -v Invalid | awk '
+  scutil --nc list | grep -v '^...Invalid' | awk '
     BEGIN         { FS="\"" }
     /\[(PPP:L2TP)|(IPSec)|(PPP:PPTP)\]/  { print $2 }
   ' | sort


### PR DESCRIPTION
fix bug introduced in 3468a18, limit the grep so
connections with "Invalid" in its name are not ignored
